### PR TITLE
Add support for csf.fignore file

### DIFF
--- a/manifests/fignore.pp
+++ b/manifests/fignore.pp
@@ -1,0 +1,9 @@
+# csf::fignore
+define csf::fignore($program = $title, $ensure = 'present', $comment = '') {
+  csf::global { "csf-global-fignore-${program}":
+    ensure    => $ensure,
+    ipaddress => $program,
+    type      => 'fignore',
+    comment   => $comment,
+  }
+}

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -8,6 +8,7 @@ define csf::global($ipaddress = '127.0.0.1', $type = 'ignore', $ensure = 'presen
     default: { fail( "unknown value ${type}" ) }
     'ignore',
     'pignore',
+    'fignore',
     'deny',
     'allow': {
       file_line { "csf-${ipaddress}-${type}":


### PR DESCRIPTION
Coupled with last month's csf.pignore PR, this commit adds support for adding lines into /etc/csf/csf.fignore.